### PR TITLE
fix, refactor: TS support for Jest, linting fixes, some other small fixes

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,9 @@ const createJestConfig = nextJest({
 });
 
 const config: Config = {
+  //enables typescript support
+  preset: 'ts-jest',
+
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@typescript-eslint/eslint-plugin": "^8.0.1",
         "@typescript-eslint/parser": "^8.0.1",
         "eslint": "^8.57.0",
         "eslint-config-next": "14.2.5",
@@ -1845,6 +1846,61 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.0.1.tgz",
+      "integrity": "sha512-5g3Y7GDFsJAnY4Yhvk8sZtFfV6YNF2caLzjrRPUBzewjPCaj0yokePB4LJSobyCzGMzjZZYFbwuzbfDHlimXbQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.0.1",
+        "@typescript-eslint/type-utils": "8.0.1",
+        "@typescript-eslint/utils": "8.0.1",
+        "@typescript-eslint/visitor-keys": "8.0.1",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+        "eslint": "^8.57.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.1.tgz",
+      "integrity": "sha512-CBFR0G0sCt0+fzfnKaciu9IBsKvEKYwN9UZ+eeogK1fYHg4Qxk1yf/wLQkLXlq8wbU2dFlgAesxt8Gi76E8RTA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.0.1",
+        "@typescript-eslint/types": "8.0.1",
+        "@typescript-eslint/typescript-estree": "8.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.0.1.tgz",
@@ -1888,6 +1944,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.0.1.tgz",
+      "integrity": "sha512-+/UT25MWvXeDX9YaHv1IS6KI1fiuTto43WprE7pgSMswHbn1Jm9GEM4Txp+X74ifOWV8emu2AWcbLhpJAvD5Ng==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.0.1",
+        "@typescript-eslint/utils": "8.0.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.1.tgz",
+      "integrity": "sha512-CBFR0G0sCt0+fzfnKaciu9IBsKvEKYwN9UZ+eeogK1fYHg4Qxk1yf/wLQkLXlq8wbU2dFlgAesxt8Gi76E8RTA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "8.0.1",
+        "@typescript-eslint/types": "8.0.1",
+        "@typescript-eslint/typescript-estree": "8.0.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.5",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,19 @@
-import { ProductGrid } from 'src/components/ProductGrid';
+import { ProductGrid } from '@/components/ProductGrid';
+import { Filters } from '@/components/Filters';
 
 export default function Home() {
   return (
-    <main className='flex min-h-screen flex-col items-center justify-between p-24'>
-      <div>
-        <h1 className="text-5xl font-bold">Mobile Phones & Accessories</h1>
+    <main className='flex min-h-screen flex-col items-center justify-between gap-6 p-6 md:gap-12 md:p-12'>
+      <header className='flex flex-col gap-4'>
+        <h1 className='text-3xl md:text-5xl font-bold'>Mobile Phones & Accessories</h1>
+        <p className='text-base md:text-2xl'>
+          Discover the latest mobile phones and accessories to enhance your
+          digital lifestyle. From sleek designs to powerful features, our
+          selection offers something for everyone.
+        </p>
+      </header>
+      <div className='w-full md:grid md:grid-cols-[1fr_4fr]'>
+        <Filters />
         <ProductGrid />
       </div>
     </main>

--- a/src/components/ColorDots.test.jsx
+++ b/src/components/ColorDots.test.jsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ColorDots } from './ColorDots';
-import { mapColorToHex } from '@/utils/colorUtils';
 
 jest.mock('@/utils/colorUtils', () => ({
   mapColorToHex: jest.fn((color) => {

--- a/src/components/Filters.tsx
+++ b/src/components/Filters.tsx
@@ -1,0 +1,3 @@
+export const Filters = () => {
+  return <div>Filters</div>;
+};

--- a/src/components/OrderNowBtn.test.jsx
+++ b/src/components/OrderNowBtn.test.jsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ButtonCTA } from '@/components/ButtonCTA';
+import { OrderNowBtn } from './OrderNowBtn';
 
-describe('ButtonCTA', () => {
+describe('OrderNowBtn', () => {
   it('renders the button text', () => {
-    render(<ButtonCTA onClick={() => {}} />);
+    render(<OrderNowBtn onClick={() => {}} />);
 
     const buttonText = screen.getByText(/Order now/i);
 
@@ -12,7 +12,7 @@ describe('ButtonCTA', () => {
 
   it('calls the onClick function when the button is clicked', () => {
     const onClick = jest.fn();
-    render(<ButtonCTA onClick={onClick} />);
+    render(<OrderNowBtn onClick={onClick} />);
 
     const button = screen.getByRole('button');
     fireEvent.click(button);

--- a/src/components/OrderNowBtn.tsx
+++ b/src/components/OrderNowBtn.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { FaArrowRight } from 'react-icons/fa6';
 
-interface ButtonCTAProps {
+interface OrderNowBtnProps {
   onClick: () => void;
 }
 
 
 
-export const ButtonCTA: React.FC<ButtonCTAProps> = ({onClick}) => {
+export const OrderNowBtn: React.FC<OrderNowBtnProps> = ({onClick}) => {
   return (
     <button
       className='flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-white hover:bg-primary-light'

--- a/src/components/ProductCard.test.jsx
+++ b/src/components/ProductCard.test.jsx
@@ -1,17 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ProductCard } from './ProductCard';
-
-jest.mock('@/components/ButtonCTA', () => ({
-  ButtonCTA: () => <div data-testid="button-cta">Button CTA</div>,
-}));
-
-jest.mock('@/components/ColorDots', () => ({
-  ColorDots: () => <div data-testid="color-dots">Color Dots</div>,
-}));
-
-jest.mock('@/components/StockStatus', () => ({
-  StockStatus: () => <div data-testid="stock-status">Stock Status</div>,
-}));
 
 const mockProps = {
   productId: '1',
@@ -27,19 +15,42 @@ const mockProps = {
   productType: 'phone',
 };
 
+jest.mock('@/components/OrderNowBtn', () => ({
+  OrderNowBtn: () => <div data-testid="order-now-btn">Order now</div>,
+}));
+
+jest.mock('@/components/ColorDots', () => ({
+  ColorDots: ({ availableColors, onColorSelect }) => <div data-testid="color-dots">
+    {availableColors.map((colorOption) => (
+      <div
+        key={colorOption.color}
+        data-testid={`color-dot-${colorOption.color}`}
+        onClick={() => onColorSelect(colorOption)}
+      >
+        {colorOption.color}
+      </div>
+    ))}
+  </div>,
+}));
+
+jest.mock('@/components/StockStatus', () => ({
+  StockStatus: () => <div data-testid="stock-status">Stock Status</div>,
+}));
+
 describe('ProductCard', () => {
-  it('renders the ButtonCTA, ColorDots, and StockStatus components', () => {
+  it('renders the OrderNowBtn, ColorDots, and StockStatus components', () => {
     render(<ProductCard {...mockProps} />);
 
-    const buttonCTA = screen.getByTestId('button-cta');
+    const OrderNowBtn = screen.getByTestId('order-now-btn');
     const colorDots = screen.getByTestId('color-dots');
     const stockStatus = screen.getByTestId('stock-status');
 
-    expect(buttonCTA).toBeInTheDocument();
+    expect(OrderNowBtn).toBeInTheDocument();
     expect(colorDots).toBeInTheDocument();
     expect(stockStatus).toBeInTheDocument();
   });
-  it('renders the correct data for the first product from mockData', () => {
+
+  it('renders the data for a product based on provided props', () => {
     render(<ProductCard {...mockProps} />);
 
     const productImage = screen.getByAltText(
@@ -56,4 +67,32 @@ describe('ProductCard', () => {
     expect(shortDescription).toBeInTheDocument();
     expect(pricePerMonth).toBeInTheDocument();
   });
+
+  it('renders correct alt tag for a selected color option', () => {
+    render(<ProductCard {...mockProps} />);
+
+    const productImage = screen.getByAltText(
+      `${mockProps.brandName} ${mockProps.modelName} ${mockProps.availableColors[0].color}`
+    );
+
+    expect(productImage).toHaveAttribute('src', mockProps.availableColors[0].image);
+  });
+
+  it('updates image upon selecting another color option', () => {
+    render(<ProductCard {...mockProps} />);
+
+    mockProps.availableColors.forEach((colorOption) => {
+      const colorDot = screen.getByTestId(`color-dot-${colorOption.color}`);
+      fireEvent.click(colorDot);
+
+      const phoneImage = screen.getByAltText(
+        `${mockProps.brandName} ${mockProps.modelName} ${colorOption.color}`
+      );
+
+      expect(phoneImage).toHaveAttribute('src', colorOption.image);
+    })
+
+
+  })
+
 });

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,31 +1,34 @@
 'use client';
 
 import React, { useState } from 'react';
-import { ButtonCTA } from '@/components/ButtonCTA';
+import { OrderNowBtn } from '@/components/OrderNowBtn';
 import { ColorDots } from '@/components/ColorDots';
 import { StockStatus } from '@/components/StockStatus';
+import Image from 'next/image';
 
 export const ProductCard: React.FC<ProductCardProps> = ({
-  productId,
   brandName,
   modelName,
   productImage,
   availableColors,
   shortDescription,
   pricePerMonth,
-  productType,
 }) => {
   const [selectedColor, setSelectedColor] = useState<ColorOption>(
     availableColors[0]
   );
 
   return (
-    <div className='rounded-lg bg-grey-100 outline outline-1 outline-grey-200'>
-      <div className='flex w-[320px] flex-col gap-4 p-6'>
+    <div className='ratio:[318/336] w-[318px] rounded-lg bg-grey-100 outline outline-1 outline-grey-200'>
+      <div className='flex flex-col gap-4 p-6'>
         <figure className='grid h-[116px] grid-cols-2 items-center justify-center'>
           <div className='mx-auto max-w-[100px]'>
-            <img
-              src={selectedColor ? selectedColor.image : productImage}
+            <Image
+              src={
+                selectedColor && typeof selectedColor.image === 'string'
+                  ? selectedColor.image
+                  : productImage
+              }
               alt={`${brandName} ${modelName} ${
                 selectedColor ? selectedColor.color : availableColors[0]
               }`}
@@ -48,7 +51,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           <p className='font-base font-bold text-grey-900'>
             {pricePerMonth}€/month
           </p>
-          <ButtonCTA onClick={() => alert('Added to cart')} />
+          <OrderNowBtn onClick={() => alert('Added to cart')} />
         </div>
       </div>
       <hr />

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -22,8 +22,10 @@ export const ProductCard: React.FC<ProductCardProps> = ({
     <div className='ratio:[318/336] w-[318px] rounded-lg bg-grey-100 outline outline-1 outline-grey-200'>
       <div className='flex flex-col gap-4 p-6'>
         <figure className='grid h-[116px] grid-cols-2 items-center justify-center'>
-          <div className='mx-auto max-w-[100px]'>
+          <div className='mx-auto max-w-[100px] max-h-[116px]'>
             <Image
+              width={100}
+              height={116}
               src={
                 selectedColor && typeof selectedColor.image === 'string'
                   ? selectedColor.image
@@ -32,7 +34,7 @@ export const ProductCard: React.FC<ProductCardProps> = ({
               alt={`${brandName} ${modelName} ${
                 selectedColor ? selectedColor.color : availableColors[0]
               }`}
-              className='w-full'
+              className="max-h-[116px]"
             />
           </div>
           <figcaption className='flex flex-col gap-3'>

--- a/src/components/ProductGrid.test.jsx
+++ b/src/components/ProductGrid.test.jsx
@@ -1,14 +1,21 @@
 import { render, screen } from '@testing-library/react';
+import PropTypes from 'prop-types';
 import { ProductGrid } from '@/components/ProductGrid';
 import { products } from '@/data/mockData';
 
-jest.mock('@/components/ProductCard', () => ({
-  ProductCard: ({ productId, brandName, modelName }) => (
+jest.mock('@/components/ProductCard', () => {
+  const ProductCard = ({ productId, brandName, modelName }) => (
     <div data-testid={`product-card-${productId}`}>
       {brandName} {modelName}
     </div>
-  ),
-}));
+  );
+  ProductCard.propTypes = {
+    productId: PropTypes.number.isRequired,
+    brandName: PropTypes.string.isRequired,
+    modelName: PropTypes.string.isRequired,
+  };
+  return { ProductCard };
+});
 
 describe('ProductGrid', () => {
   it('renders a product card for each product', () => {

--- a/src/components/ProductGrid.tsx
+++ b/src/components/ProductGrid.tsx
@@ -2,21 +2,11 @@ import React from 'react';
 import { ProductCard } from '@/components/ProductCard';
 import { products } from '@/data/mockData';
 
-export const ProductGrid = () => {
+export const ProductGrid: React.FC = () => {
   return (
     <div className='flex flex-wrap gap-4'>
       {products.map((product: ProductCardProps) => (
-        <ProductCard
-          key={product.productId}
-          productId={product.productId}
-          productImage={product.productImage}
-          brandName={product.brandName}
-          modelName={product.modelName}
-          availableColors={product.availableColors}
-          shortDescription={product.shortDescription}
-          pricePerMonth={product.pricePerMonth}
-          productType={product.productType}
-        />
+        <ProductCard key={product.productId} {...product} />
       ))}
     </div>
   );


### PR DESCRIPTION
* added TS support for Jest - it still isn't pretty, as each test that is for a typed component needs importing propTypes and writing types - I don't like this solution, but that's because we are using TypeSciprt and Jest does not have TypeScript support out of the box. we can consider switching to another testing tool that has TS support build-in
* improved naming of some components, to be more informative
* added empty "Filters" component to visualize better the UI
* refactored <img> to use <Image> from Next instead
* wrote test for product card that checks image urls upon selecting other color variants

sorry for a big PR ;D